### PR TITLE
AJ fix pip symlinks

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -99,6 +99,15 @@ class graphite::config inherits graphite::params {
       owner   => $carbon_user;
   }
 
+  # Lets ensure graphite.db owner is the same as gr_web_user
+  file {
+    '/opt/graphite/storage/graphite.db':
+      ensure  => file,
+      group   => $::graphite::gr_web_group,
+      mode    => '0644',
+      owner   => $::graphite::gr_web_user;
+  }
+
   # Deploy configfiles
   file {
     '/opt/graphite/webapp/graphite/local_settings.py':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,15 +86,56 @@ class graphite::install inherits graphite::params {
   if $::graphite::gr_pip_install {
     # workaround for unusual graphite install target:
     # https://github.com/graphite-project/carbon/issues/86
-    file { $::graphite::params::carbon_pip_hack_source :
+
+    unless $::osfamily =~ /(Debian|RedHat)/ {
+      fail('unsupported os.')
+    }
+
+    $carbon_pip_hack_source = $::osfamily ? {
+      'Debian' => "/usr/lib/python2.7/dist-packages/carbon-${::graphite::gr_carbon_ver}-py2.7.egg-info",
+      'RedHat' => $::operatingsystemrelease ? {
+        /^6\.\d+$/ => "/usr/lib/python2.6/site-packages/carbon-${::graphite::gr_carbon_ver}-py2.6.egg-info",
+        /^7\.\d+/  => "/usr/lib/python2.7/site-packages/carbon-${::graphite::gr_carbon_ver}-py2.7.egg-info",
+        default    => fail("Unsupported RedHat release: '${::operatingsystemrelease}'"),
+      },
+    }
+
+    $carbon_pip_hack_target = $::osfamily ? {
+      'Debian' => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ver}-py2.7.egg-info",
+      'RedHat' => $::operatingsystemrelease ? {
+        /^6\.\d+$/ => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ve}-py2.6.egg-info",
+        /^7\.\d+/  => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ve}-py2.7.egg-info",
+        default    => fail("Unsupported RedHat release: '${::operatingsystemrelease}'"),
+      },
+    }
+
+    $gweb_pip_hack_source = $::osfamily ? {
+      'Debian' => "/usr/lib/python2.7/dist-packages/graphite_web-${::graphite::gr_graphite_ver}-py2.7.egg-info",
+      'RedHat' => $::operatingsystemrelease ? {
+        /^6\.\d+$/ => "/usr/lib/python2.6/site-packages/graphite_web-${::graphite::gr_graphite_ver}-py2.6.egg-info",
+        /^7\.\d+/  => "/usr/lib/python2.7/site-packages/graphite_web-${::graphite::gr_graphite_ver}-py2.7.egg-info",
+        default    => fail("Unsupported RedHat release: '${::operatingsystemrelease}'"),
+      },
+    }
+
+    $gweb_pip_hack_target = $::osfamily ? {
+      'Debian' => "/opt/graphite/webapp/graphite_web-${::graphite::gr_graphite_ver}-py2.7.egg-info",
+      'RedHat' => $::operatingsystemrelease ? {
+        /^6\.\d+$/ => "/opt/graphite/webapp/graphite_web-${::graphite::gr_graphite_ver}-py2.6.egg-info",
+        /^7\.\d+/  => "/opt/graphite/webapp/graphite_web-${::graphite::gr_graphite_ver}-py2.7.egg-info",
+        default    => fail("Unsupported RedHat release: '${::operatingsystemrelease}'"),
+      },
+    }
+
+    file { $carbon_pip_hack_source :
       ensure  => link,
-      target  => $::graphite::params::carbon_pip_hack_target,
+      target  => $carbon_pip_hack_target,
       require => Package['whisper'],
     }
 
-    file { $::graphite::params::gweb_pip_hack_source :
+    file { $gweb_pip_hack_source :
       ensure  => link,
-      target  => $::graphite::params::gweb_pip_hack_target,
+      target  => $gweb_pip_hack_target,
       require => Package['whisper'],
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -103,8 +103,8 @@ class graphite::install inherits graphite::params {
     $carbon_pip_hack_target = $::osfamily ? {
       'Debian' => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ver}-py2.7.egg-info",
       'RedHat' => $::operatingsystemrelease ? {
-        /^6\.\d+$/ => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ve}-py2.6.egg-info",
-        /^7\.\d+/  => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ve}-py2.7.egg-info",
+        /^6\.\d+$/ => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ver}-py2.6.egg-info",
+        /^7\.\d+/  => "/opt/graphite/lib/carbon-${::graphite::gr_carbon_ver}-py2.7.egg-info",
         default    => fail("Unsupported RedHat release: '${::operatingsystemrelease}'"),
       },
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,15 +24,6 @@ class graphite::params {
   $whisper_pkg        = 'whisper'
   $whisper_ver        = '0.9.12'
 
-  $whisper_dl_url = "http://github.com/graphite-project/whisper/archive/${::graphite::params::whisper_ver}.tar.gz"
-  $whisper_dl_loc = "${build_dir}/whisper-${::graphite::params::whisper_ver}"
-
-  $webapp_dl_url = "http://github.com/graphite-project/graphite-web/archive/${::graphite::params::graphite_ver}.tar.gz"
-  $webapp_dl_loc = "${build_dir}/graphite-web-${::graphite::params::graphite_ver}"
-
-  $carbon_dl_url = "https://github.com/graphite-project/carbon/archive/${::graphite::params::carbon_ver}.tar.gz"
-  $carbon_dl_loc = "${build_dir}/carbon-${::graphite::params::carbon_ver}"
-
   $install_prefix      = '/opt/'
   $enable_carbon_relay = false
   $nginxconf_dir       = '/etc/nginx/sites-available'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,12 +43,6 @@ class graphite::params {
 
       $python_dev_pkg = 'python-dev'
 
-      # see https://github.com/graphite-project/carbon/issues/86
-      $carbon_pip_hack_source = "/usr/lib/python2.7/dist-packages/carbon-${carbon_ver}-py2.7.egg-info"
-      $carbon_pip_hack_target = "/opt/graphite/lib/carbon-${carbon_ver}-py2.7.egg-info"
-      $gweb_pip_hack_source   = "/usr/lib/python2.7/dist-packages/graphite_web-${graphite_ver}-py2.7.egg-info"
-      $gweb_pip_hack_target   = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.7.egg-info"
-
       $graphitepkgs = [
         'python-tz',
         'python-cairo',
@@ -93,11 +87,7 @@ class graphite::params {
       # see https://github.com/graphite-project/carbon/issues/86
       case $::operatingsystemrelease {
         /^6\.\d+$/: {
-          $carbon_pip_hack_source     = "/usr/lib/python2.6/site-packages/carbon-${carbon_ver}-py2.6.egg-info"
-          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbon_ver}-py2.6.egg-info"
-          $apache_24               = false
-          $gweb_pip_hack_source       = "/usr/lib/python2.6/site-packages/graphite_web-${graphite_ver}-py2.6.egg-info"
-          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.6.egg-info"
+          $apache_24    = false
           $graphitepkgs = [
             'Django14',
             'MySQL-python',
@@ -116,11 +106,7 @@ class graphite::params {
         }
 
         /^7\.\d+/: {
-          $carbon_pip_hack_source     = "/usr/lib/python2.7/site-packages/carbon-${carbon_ver}-py2.7.egg-info"
-          $carbon_pip_hack_target     = "/opt/graphite/lib/carbon-${carbon_ver}-py2.7.egg-info"
-          $apache_24               = true
-          $gweb_pip_hack_source       = "/usr/lib/python2.7/site-packages/graphite_web-${graphite_ver}-py2.7.egg-info"
-          $gweb_pip_hack_target       = "/opt/graphite/webapp/graphite_web-${graphite_ver}-py2.7.egg-info"
+          $apache_24    = true
           $graphitepkgs = [
             'python-django',
             'MySQL-python',


### PR DESCRIPTION
This PR fixes 2 things

* The symlinks for pip to pick up the version of the packages was being hardcoded to `0.9.12` and since `graphite::params` class is not parameterized I had to move the symlink sources and targets to `install.pp` so the version we pass is in scope
* By default the `graphite.db` file is `root.root` for user/group which causes the db to be read-only. Ensuring the file perms are the same as web user/group so the db is writeable.

Also did a little clean up and removed a bunch of unused params as this was causing confusion as to how the packages were being installed, symlinked, etc.

@jbarbuto @jamessthompson @jeremiahshirk 